### PR TITLE
Use app template on android and install to Qt plugin dir

### DIFF
--- a/sqlitecipher/sqlitecipher.pro
+++ b/sqlitecipher/sqlitecipher.pro
@@ -1,10 +1,17 @@
 TARGET = sqlitecipher
-TEMPLATE = lib
+android {
+    TEMPLATE = app
+} else {
+    TEMPLATE = lib
+}
 
 QT      *= core sql
 
 include($$PWD/qt_p.pri)
 include($$PWD/sqlite3/sqlite3.pri)
+
+target.path = $$[QT_INSTALL_PLUGINS]/sqldrivers/
+INSTALLS += target
 
 HEADERS  += $$PWD/qsql_sqlite.h
 SOURCES  += $$PWD/qsql_sqlite.cpp \


### PR DESCRIPTION
On android everything is a library used by the NDK. This means the template should be "app" in order to build a shared library usable by other Qt applications.

Other than that make installing easier, no need to manually copy and paste plugins now.