### PR TITLE
ci: remove march=native optim to be able to cross-compile

### DIFF
--- a/sqlitecipher/sqlitecipher.pro
+++ b/sqlitecipher/sqlitecipher.pro
@@ -43,5 +43,3 @@ PLUGIN_TYPE = sqldrivers
 load(qt_plugin)
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
-
-QMAKE_CFLAGS += -march=native


### PR DESCRIPTION
Hello!
I want to cross-compile your library. So I remove the march=native optim.
Thank you